### PR TITLE
Analyze files in directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.6.8-stretch
 
 # Common requirements
 RUN apt-get update \

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ The example above mounts the current directory ``pwd`` in the virtual `tmp` dire
 docker run -it --rm -v /local/path/to/your/audio/file.wav:/audio.wav -v /local/path/to/output_directory/:/outdir mtgupf/ac-audio-extractor:v3 -i /audio.wav -o /outdir/analysis.json  -st
 ```
 
+You can also run the analyze on several files contained in a folder by entering directories as input and output arguments to the extractor. For instance, you can use the following command:
+
+```
+docker run -it --rm -v /local/path/to/your/input_directory/:/audio -v /local/path/to/output_directory/:/outdir mtgupf/ac-audio-extractor:v3 -i /audio/ -o /outdir/  -st
+```
+
 You can use the `--help` flag with the Audio Commons Audio Extractor so see a complete list of all available options:
 
 ```
@@ -44,9 +50,9 @@ optional arguments:
   -m, --music-pieces    include descriptors designed for music pieces
   -s, --music-samples   include descriptors designed for music samples
   -i INPUT, --input INPUT
-                        input audio file
+                        input audio file or input directory containing the audio files to analyze
   -o OUTPUT, --output OUTPUT
-                        output analysis file
+                        output analysis file or output directory where the analysis files will be saved
   -f FORMAT, --format FORMAT
                         format of the output analysis file ("json" or
                         "jsonld", defaults to "jsonld")

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The example above mounts the current directory ``pwd`` in the virtual `tmp` dire
 docker run -it --rm -v /local/path/to/your/audio/file.wav:/audio.wav -v /local/path/to/output_directory/:/outdir mtgupf/ac-audio-extractor:v3 -i /audio.wav -o /outdir/analysis.json  -st
 ```
 
-You can also run the analyze on several files contained in a folder by entering directories as input and output arguments to the extractor. For instance, you can use the following command:
+You can also run the analysis on several files contained in a directory by entering directories as input and output arguments to the extractor. For instance, you can use the following command:
 
 ```
 docker run -it --rm -v /local/path/to/your/input_directory/:/audio -v /local/path/to/output_directory/:/outdir mtgupf/ac-audio-extractor:v3 -i /audio/ -o /outdir/  -st

--- a/analyze.py
+++ b/analyze.py
@@ -20,7 +20,7 @@ from essentia.standard import MusicExtractor, FreesoundExtractor, MonoLoader, Mo
 from rdflib import Graph, URIRef, BNode, Literal, Namespace, plugin
 from rdflib.serializer import Serializer
 from rdflib.namespace import RDF
-from argparse import ArgumentParser
+from argparse import ArgumentParser, ArgumentTypeError
 import timbral_models
 
 MORE_THAN_2_CHANNELS_EXCEPTION_MATCH_TEXT = 'Audio file has more than 2 channels'
@@ -396,4 +396,4 @@ if __name__ == '__main__':
         analyze(args.input, args.output, args.timbral_models, args.music_pieces, args.music_samples, args.format, args.uri)
 
     else:
-        Exception('Make sure input and output arguments are both files or folders')
+        raise ArgumentTypeError('Make sure input and output arguments are both files or folders')

--- a/analyze.py
+++ b/analyze.py
@@ -383,15 +383,17 @@ if __name__ == '__main__':
     args = parser.parse_args()
     logging.basicConfig(format='%(asctime)s %(levelname)s:%(message)s', level=logging.INFO if not args.verbose else logging.DEBUG)
 
-    # check if the input is a file or a folder
-    if os.path.isfile(args.input):
-        analyze(args.input, args.output, args.timbral_models, args.music_pieces, args.music_samples, args.format, args.uri)
-    # ensure that the output argument is a folder
-    elif not os.path.isfile(args.output):
+    # check if input and output arguments point to directories
+    if os.path.isdir(args.input) and os.path.isdir(args.output):
         folder = args.input
         input_files = [x for x in Path(folder).iterdir() if x.is_file()]
         for input_file in input_files:
             output_file = os.path.join(args.output, '{}_analysis.json'.format(input_file.stem))
             analyze(str(input_file), output_file, args.timbral_models, args.music_pieces, args.music_samples, args.format, args.uri)
+
+    # check if input argument points to a file
+    elif os.path.isfile(args.input):
+        analyze(args.input, args.output, args.timbral_models, args.music_pieces, args.music_samples, args.format, args.uri)
+
     else:
         Exception('Make sure input and output arguments are both files or folders')

--- a/analyze.py
+++ b/analyze.py
@@ -4,6 +4,7 @@ import json
 import math
 import hashlib
 import subprocess
+from pathlib import Path
 import numpy as np
 import logging
 import pyld
@@ -374,13 +375,23 @@ if __name__ == '__main__':
     parser.add_argument('-t', '--timbral-models', help='include descriptors computed from timbral models', action='store_const', const=True, default=False)
     parser.add_argument('-m', '--music-pieces', help='include descriptors designed for music pieces', action='store_const', const=True, default=False)
     parser.add_argument('-s', '--music-samples', help='include descriptors designed for music samples', action='store_const', const=True, default=False)
-    parser.add_argument('-i', '--input', help='input audio file', required=True)
-    parser.add_argument('-o', '--output', help='output analysis file', required=True)
+    parser.add_argument('-i', '--input', help='input audio file or input folder containing the audio files to analyze', required=True)
+    parser.add_argument('-o', '--output', help='output analysis file or output folder where the analysis files will be saved', required=True)
     parser.add_argument('-f', '--format', help='format of the output analysis file ("json" or "jsonld", defaults to "jsonld")', default="jsonld")
     parser.add_argument('-u', '--uri', help='URI for the analyzed sound (only used if "jsonld" format is chosen)', default=None)
     
     args = parser.parse_args()
     logging.basicConfig(format='%(asctime)s %(levelname)s:%(message)s', level=logging.INFO if not args.verbose else logging.DEBUG)
 
-    analyze(args.input, args.output, args.timbral_models, args.music_pieces, args.music_samples, args.format, args.uri)
-    
+    # check if the input is a file or a folder
+    if os.path.isfile(args.input):
+        analyze(args.input, args.output, args.timbral_models, args.music_pieces, args.music_samples, args.format, args.uri)
+    # ensure that the output argument is a folder
+    elif not os.path.isfile(args.output):
+        folder = args.input
+        input_files = [x for x in Path(folder).iterdir() if x.is_file()]
+        for input_file in input_files:
+            output_file = os.path.join(args.output, '{}_analysis.json'.format(input_file.stem))
+            analyze(str(input_file), output_file, args.timbral_models, args.music_pieces, args.music_samples, args.format, args.uri)
+    else:
+        Exception('Make sure input and output arguments are both files or folders')

--- a/analyze.py
+++ b/analyze.py
@@ -375,8 +375,8 @@ if __name__ == '__main__':
     parser.add_argument('-t', '--timbral-models', help='include descriptors computed from timbral models', action='store_const', const=True, default=False)
     parser.add_argument('-m', '--music-pieces', help='include descriptors designed for music pieces', action='store_const', const=True, default=False)
     parser.add_argument('-s', '--music-samples', help='include descriptors designed for music samples', action='store_const', const=True, default=False)
-    parser.add_argument('-i', '--input', help='input audio file or input folder containing the audio files to analyze', required=True)
-    parser.add_argument('-o', '--output', help='output analysis file or output folder where the analysis files will be saved', required=True)
+    parser.add_argument('-i', '--input', help='input audio file or input directory containing the audio files to analyze', required=True)
+    parser.add_argument('-o', '--output', help='output analysis file or output directory where the analysis files will be saved', required=True)
     parser.add_argument('-f', '--format', help='format of the output analysis file ("json" or "jsonld", defaults to "jsonld")', default="jsonld")
     parser.add_argument('-u', '--uri', help='URI for the analyzed sound (only used if "jsonld" format is chosen)', default=None)
     


### PR DESCRIPTION
Currently the extractor allows to run the analysis on a single file.
This PR aims at enabling to launch the analysis for several file located in a directory in a single command.
For doing so, the user needs to specify the directories for the input and output parameters of the extractor.
The python script checks if these arguments are directories, and iteratively calls the analysis on the files contained in the directory.

I had some problems building the docker image locally.
For some reason, the updated python:3 image could not access the repository containing some dependencies from the FFmpeg library. I fixed it by specifying a more precise version of python image.

If this PR is accepted, we should update the Docker image asap.